### PR TITLE
Specifying compendium version to retrieve

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,0 +1,18 @@
+.versions <- c(
+    '1.0.0',
+    '1.0.1'
+)
+# Describes the IDs assigned by Zenodo to each compendium release.
+# Should be determined from the release's URL:
+# https://zenodo.org/records/{ID IS HERE}
+.record_ids <- c(
+    '8431937',  # 1.0.0
+    '10452633'  # 1.0.1
+)
+
+# Uses the data above to build URLs for the files needed
+.data_url <- paste0('https://zenodo.org/record/', .record_ids, '/files/taxonomic_table.csv.gz')
+names(.data_url) <- .versions
+
+.coldata_url <- paste0('https://zenodo.org/record/', .record_ids, '/files/sample_metadata.tsv')
+names(.coldata_url) <- .versions

--- a/R/loader.R
+++ b/R/loader.R
@@ -1,11 +1,12 @@
-.getCompendiumData <- function(bfc) {
-    url <- "https://zenodo.org/record/8226567/files/taxonomic_table.csv.gz"
+.getCompendiumData <- function(version, bfc) {
+    print(paste('Retrieving compendium version',version))
+    url <- .data_url[[version]]
     rpath <- bfcrpath(bfc, url)
     data.table::fread(rpath)
 }
 
-.getCompendiumColdata <- function(bfc) {
-    url <- "https://zenodo.org/record/8226567/files/sample_metadata.tsv"
+.getCompendiumColdata <- function(version, bfc) {
+    url <- .coldata_url[[version]]
     rpath <- bfcrpath(bfc, url)
     sampdat <- as.data.frame(data.table::fread(rpath))
     rownames(sampdat) <- paste(sampdat[[2]], sampdat[[3]], sep = "_")
@@ -35,10 +36,10 @@
 #' assayNames(cpd)
 #' head(colData(cpd))
 #'
-getCompendium <- function(bfc = BiocFileCache::BiocFileCache()) {
-    dat <-.getCompendiumData(bfc)
 
-    coldat <- .getCompendiumColdata(bfc)
+getCompendium <- function(version='1.0.1', bfc = BiocFileCache::BiocFileCache()) {
+    dat <-.getCompendiumData(version, bfc)
+    coldat <- .getCompendiumColdata(version, bfc)
 
     sampnames <- dat[[2]]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Microbiome Compendium
 
 
-Our dataset includes over 170,000 samples of publicly available 16S rRNA
+Our dataset includes more than 168,000 samples of publicly available 16S rRNA
 amplicon sequencing data, all processed using the same pipeline and reference
 database.
 
@@ -35,3 +35,5 @@ on the roadmap.
 
 After loading the compendium, you will have immediate access to nearly
 170,000 microbiome samples. 
+
+The `getCompendium` function retrieves [data stored by Zenodo](https://doi.org/10.5281/zenodo.8186993) and accepts an optional parameter indicating which version to download—for example, `getCompendium('1.0.1')`. Version 1.0.1 is retrieved by default.

--- a/tests/testthat/test-test_get_coldata.R
+++ b/tests/testthat/test-test_get_coldata.R
@@ -1,6 +1,6 @@
 test_that("sample metadata download works", {
     bfc <- BiocFileCache::BiocFileCache()
-    coldat <- .getCompendiumColdata(bfc)
+    coldat <- .getCompendiumColdata('1.0.1', bfc)
     expect_equal(ncol(coldat), 11)
     expect_contains(colnames(coldat), c(
         "srs", "project", "srr", "library_strategy",

--- a/tests/testthat/test-test_get_compendium.R
+++ b/tests/testthat/test-test_get_compendium.R
@@ -1,8 +1,22 @@
-test_that("getting compendium works as expected", {
+test_that("getting compendium with defaults works as expected", {
     skip_on_ci()
     cpd <- getCompendium()
     expect_s4_class(cpd, "TreeSummarizedExperiment")
     expect_gt(nrow(cpd), 1000)
     expect_gt(ncol(cpd), 1000)
     expect_contains(assayNames(cpd), "counts")
+    # v1.0.1 corrected the name of this taxon:
+    expect_equal(max(counts(cpd)['Bacteria.Firmicutes.Clostridia.Eubacteriales.(unclassified).Alkalibaculum',]), 16)
+    expect_error(max(counts(cpd)['Bacteria.Firmicutes.Clostridia.Eubacteriales.Alkalibaculum.NA',]))
+})
+
+test_that("getting compendium with specified version works as expected", {
+    skip_on_ci()
+    cpd <- getCompendium('1.0.0')
+    expect_s4_class(cpd, "TreeSummarizedExperiment")
+    expect_gt(nrow(cpd), 1000)
+    expect_gt(ncol(cpd), 1000)
+    expect_contains(assayNames(cpd), "counts")
+    expect_equal(max(counts(cpd)['Bacteria.Firmicutes.Clostridia.Eubacteriales.Alkalibaculum.NA',]), 16)
+    expect_error(max(counts(cpd)['Bacteria.Firmicutes.Clostridia.Eubacteriales.(unclassified).Alkalibaculum',]))
 })


### PR DESCRIPTION
This would still require manual updates when we have a new release, but this will at least give users the option to select a version if they want to. I should also highlight that this defaults to v1.0.1, rather than just whatever the latest version is, but I'm not sure if there's a convention for this with packages linked to datasets.